### PR TITLE
correct install info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ docposter is an experimental format to prepare posters in Markdown and HTML/CSS 
 ## Installing docposter
 
 ```bash
-quarto use template bbucior/docposter
+quarto use template bbucior/docposter@master
 ```
 
 This command will install the extension and create an example qmd file and _quarto.yml project that you can use as a starting place for your poster.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,7 +7,7 @@ project:
   post-render:
     # Also convert the poster html output to pdf.
     # Comment out this chrome_pdf.R step if only the html output is desired.
-    - _extensions/docposter/R/chrome_pdf.R 
+    - _extensions/bbucior/docposter/R/chrome_pdf.R 
 
 format:
   docposter-html:

--- a/template.qmd
+++ b/template.qmd
@@ -141,7 +141,7 @@ For more information, please visit the project page at <https://github.com/bbuci
 
 ### Installation and usage {.fullwidth}
 
-* Run `quarto use template bbucior/docposter` to install the package in your local directory.
+* Run `quarto use template bbucior/docposter@master` to install the package in your local directory.
 * Run `quarto render` within your project to compile the poster to html and pdf.
 
 ### Customizing the template


### PR DESCRIPTION
Dear @bbucior,

I wanted to try out the docposter quarto template and noticed I could not follow the install instruction. After some research I found out that it is because the main branch is called master, and then one needs `quarto use template bbucior/docposter@master` instead of `quarto use template bbucior/docposter`.

I adapted this in the README.md and template.qmd. 

In addition, I noticed the pdf did not generate automatically when I used the install instruction. I found out this has to do with the indication of the folder structure for post-render in _quarto.yml not containing the username bbucior (which is automatically done when using quarto use template). I therefore added bbucior there to make the postrender work automatically when the template is used.